### PR TITLE
enhacing delete from array by name, previously was only by index

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -37,11 +37,37 @@ func DeleteInFile(file string, path string) error {
 	return WriteYaml(yaml, file)
 }
 
+func stringInSlice(element string, array []interface{}) (bool, int){
+	for i := 0; i < len(array); i++ {
+	 if array[i] == element {
+		 return true, i
+	 }
+
+  }
+	return false, 0
+}
+
 func Delete(yml *simpleyaml.Yaml, path string) error {
 	propsArr := strings.Split(path, ".")
 	propName := propsArr[len(propsArr)-1]
 	props := propsArr[:len(propsArr)-1]
 	newPath := strings.Join(props, ".")
+
+	yaml_pointer, _ := get(yml, newPath)
+	path_array, _ := yaml_pointer.Array()
+	doesNameExist, my_index := stringInSlice(propName, path_array)
+
+  if doesNameExist == true {
+		tmp, props := get(yml, newPath)
+		prop, err := tmp.Array()
+		if err != nil {
+			return err
+		}
+		prop = append(prop[:my_index], prop[my_index+1:]...)
+
+		updateYaml(yml, props, prop)
+		return nil
+  }
 
 	if index, err := strconv.Atoi(propName); err == nil {
 		tmp, props := get(yml, newPath)
@@ -49,13 +75,11 @@ func Delete(yml *simpleyaml.Yaml, path string) error {
 		if err != nil {
 			return err
 		}
-
 		prop = append(prop[:index], prop[index+1:]...)
 
 		updateYaml(yml, props, prop)
 		return nil
 	}
-
 	if strings.Contains(propName, ":") {
 		tmp, props := get(yml, newPath)
 		prop, err := tmp.Array()

--- a/delete_test.go
+++ b/delete_test.go
@@ -2,7 +2,7 @@ package goml_test
 
 import (
 	. "github.com/JulzDiverse/goml"
-	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/smallfish/simpleyaml"
@@ -14,7 +14,7 @@ var _ = Describe("Delete", func() {
 
 	BeforeEach(func() {
 		yaml := `map:
-  name: fosil
+  name: foo
 
 array:
 - bar
@@ -49,7 +49,6 @@ mapArray:
 	})
 
 	It("should delete a value from an array based on index", func() {
-		fmt.Println("ss")
 		err = Delete(yml, "array.0")
 		Expect(err).NotTo(HaveOccurred())
 

--- a/delete_test.go
+++ b/delete_test.go
@@ -2,7 +2,7 @@ package goml_test
 
 import (
 	. "github.com/JulzDiverse/goml"
-
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/smallfish/simpleyaml"
@@ -14,7 +14,7 @@ var _ = Describe("Delete", func() {
 
 	BeforeEach(func() {
 		yaml := `map:
-  name: foo
+  name: fosil
 
 array:
 - bar
@@ -32,7 +32,7 @@ mapArray:
   boo: laa`
 
 		yml, err = simpleyaml.NewYaml([]byte(yaml))
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(	HaveOccurred())
 	})
 
 	It("should delete a value from a map", func() {
@@ -43,7 +43,13 @@ mapArray:
 		Expect(err).To(MatchError("property not found"))
 	})
 
-	It("should delete a value from an array ", func() {
+	It("should delete a value from an array based on name", func() {
+		err = Delete(yml, "array.bar")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should delete a value from an array based on index", func() {
+		fmt.Println("ss")
 		err = Delete(yml, "array.0")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -52,6 +58,7 @@ mapArray:
 
 		err = Delete(yml, "array.:zar")
 		Expect(err).NotTo(HaveOccurred())
+
 		_, err = Get(yml, "array.:zar")
 		Expect(err).To(MatchError("property not found"))
 	})


### PR DESCRIPTION
Can we add this enhancement, so we can delete an element of array based on his name, rather than the index. We need more use cases for arrays nested in arrays, but so far for the current use cases in the test files, this should work.
Regards,
Enrique