### PR TITLE
Make goml set work with arrays on top-level

### DIFF
--- a/set_test.go
+++ b/set_test.go
@@ -1,6 +1,9 @@
 package goml_test
 
 import (
+	"io/ioutil"
+	"os"
+
 	. "github.com/JulzDiverse/goml"
 
 	. "github.com/onsi/ginkgo"
@@ -12,8 +15,9 @@ var _ = Describe("Set", func() {
 	var yml *simpleyaml.Yaml
 	var err error
 
-	BeforeEach(func() {
-		yaml := `map:
+	Context("Top-level is map", func() {
+		BeforeEach(func() {
+			yaml := `map:
   name: foo
 
 array:
@@ -31,56 +35,80 @@ mapArray:
 - foo: var
   boo: laa`
 
-		yml, err = simpleyaml.NewYaml([]byte(yaml))
-		Expect(err).NotTo(HaveOccurred())
-	})
+			yml, err = simpleyaml.NewYaml([]byte(yaml))
+			Expect(err).NotTo(HaveOccurred())
+		})
 
-	It("should add an value to an array", func() {
-		err = Set(yml, "array.2", "bumblebee")
-		Expect(err).NotTo(HaveOccurred())
-		err = Set(yml, "array.+", "optimusPrime")
-		Expect(err).NotTo(HaveOccurred())
-		err = Set(yml, "mapArray.0.foo", "wolverine")
-		Expect(err).NotTo(HaveOccurred())
-		err = Set(yml, "mapArray.foo:var.boo", "baymax")
-		Expect(err).NotTo(HaveOccurred())
+		It("should add an value to an array", func() {
+			err = Set(yml, "array.2", "bumblebee")
+			Expect(err).NotTo(HaveOccurred())
+			err = Set(yml, "array.+", "optimusPrime")
+			Expect(err).NotTo(HaveOccurred())
+			err = Set(yml, "mapArray.0.foo", "wolverine")
+			Expect(err).NotTo(HaveOccurred())
+			err = Set(yml, "mapArray.foo:var.boo", "baymax")
+			Expect(err).NotTo(HaveOccurred())
 
-		Expect(Get(yml, "array.2")).To(Equal("bumblebee"))
-		Expect(Get(yml, "array.3")).To(Equal("optimusPrime"))
-		Expect(Get(yml, "mapArray.0.foo")).To(Equal("wolverine"))
-		Expect(Get(yml, "mapArray.foo:var.boo")).To(Equal("baymax"))
+			Expect(Get(yml, "array.2")).To(Equal("bumblebee"))
+			Expect(Get(yml, "array.3")).To(Equal("optimusPrime"))
+			Expect(Get(yml, "mapArray.0.foo")).To(Equal("wolverine"))
+			Expect(Get(yml, "mapArray.foo:var.boo")).To(Equal("baymax"))
 
-		err = Set(yml, "array.:optimusPrime", "pikachu")
-		Expect(Get(yml, "array.:pikachu")).To(Equal("pikachu"))
-		err = Set(yml, "mapArray.foo:wolverine.arr.0", "new")
-		Expect(Get(yml, "mapArray.foo:wolverine.arr.0")).To(Equal("new"))
-	})
+			err = Set(yml, "array.:optimusPrime", "pikachu")
+			Expect(Get(yml, "array.:pikachu")).To(Equal("pikachu"))
+			err = Set(yml, "mapArray.foo:wolverine.arr.0", "new")
+			Expect(Get(yml, "mapArray.foo:wolverine.arr.0")).To(Equal("new"))
+		})
 
-	Context("If a path does not exist", func() {
-		It("should create the path", func() {
-			err = Set(yml, "map.awesome", "bam")
-			Expect(err).ToNot(HaveOccurred())
+		Context("If a path does not exist", func() {
+			It("should create the path", func() {
+				err = Set(yml, "map.awesome", "bam")
+				Expect(err).ToNot(HaveOccurred())
 
-			Expect(Get(yml, "map.awesome")).To(Equal("bam"))
+				Expect(Get(yml, "map.awesome")).To(Equal("bam"))
 
-			err = Set(yml, "mapArray.luffy:gomugomuno.beat", "katakuri")
-			Expect(err).ToNot(HaveOccurred())
+				err = Set(yml, "mapArray.luffy:gomugomuno.beat", "katakuri")
+				Expect(err).ToNot(HaveOccurred())
 
-			Expect(Get(yml, "mapArray.luffy:gomugomuno.beat")).To(Equal("katakuri"))
+				Expect(Get(yml, "mapArray.luffy:gomugomuno.beat")).To(Equal("katakuri"))
+			})
+		})
+
+		Context("using the | delimiter", func() {
+			It("should add an value to an array", func() {
+				err = Set(yml, "mapArray.foo|var.boo", "baymax")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(Get(yml, "mapArray.foo|var.boo")).To(Equal("baymax"))
+				err = Set(yml, "array.+", "pikachu")
+				Expect(Get(yml, "array.|pikachu")).To(Equal("pikachu"))
+				err = Set(yml, "array.|pikachu", "ruffy")
+				Expect(Get(yml, "array.|ruffy")).To(Equal("ruffy"))
+				err = Set(yml, "mapArray.foo|bar.arr.0", "new")
+				Expect(Get(yml, "mapArray.foo|bar.arr.0")).To(Equal("new"))
+			})
 		})
 	})
 
-	Context("using the | delimiter", func() {
-		It("should add an value to an array", func() {
-			err = Set(yml, "mapArray.foo|var.boo", "baymax")
+	Context("Top-level is array", func() {
+		var tempFile *os.File
+
+		BeforeEach(func() {
+			tempFile, err = ioutil.TempFile("", "")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(Get(yml, "mapArray.foo|var.boo")).To(Equal("baymax"))
-			err = Set(yml, "array.+", "pikachu")
-			Expect(Get(yml, "array.|pikachu")).To(Equal("pikachu"))
-			err = Set(yml, "array.|pikachu", "ruffy")
-			Expect(Get(yml, "array.|ruffy")).To(Equal("ruffy"))
-			err = Set(yml, "mapArray.foo|bar.arr.0", "new")
-			Expect(Get(yml, "mapArray.foo|bar.arr.0")).To(Equal("new"))
+			_, err = tempFile.WriteString(`- key1: value1
+- key2: value2`)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tempFile.Close()).To(Succeed())
+		})
+
+		AfterEach(func() {
+			os.Remove(tempFile.Name())
+		})
+
+		It("changes an element in the array without error", func() {
+			err = SetInFile(tempFile.Name(), "0.key1", "bumblebee")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(GetFromFile(tempFile.Name(), "0.key1")).To(Equal("bumblebee"))
 		})
 	})
 })

--- a/utils.go
+++ b/utils.go
@@ -72,7 +72,18 @@ func convertValueType(val interface{}) interface{} {
 }
 
 func WriteYaml(yml *simpleyaml.Yaml, file string) error {
-	goml, err := yml.Map()
+	var (
+		err  error
+		goml interface{}
+	)
+	switch {
+	case yml.IsMap():
+		goml, err = yml.Map()
+	case yml.IsArray():
+		goml, err = yml.Array()
+	default:
+		err = errors.New("Unexpected yml structure after manipulation")
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixes issues when manipulating ops-files which are an array on top-level, not a map.