### PR TITLE
Exit with code 1 when cmd.Run() returns error

### DIFF
--- a/cmd/goml/main.go
+++ b/cmd/goml/main.go
@@ -75,7 +75,11 @@ func main() {
 			},
 		},
 	}
-	cmd.Run(os.Args)
+
+	err := cmd.Run(os.Args)
+	if err != nil {
+		os.Exit(1)
+	}
 }
 
 func getParam(c *cli.Context) {


### PR DESCRIPTION
As discussed in #8, I think this is the way we want it, right?

![image](https://user-images.githubusercontent.com/15948574/102607771-2713b680-4129-11eb-8cc7-3787741f6d4c.png)